### PR TITLE
[Fix] Return the scene_node read by STL or 3MF reader

### DIFF
--- a/CommonComReader.py
+++ b/CommonComReader.py
@@ -216,4 +216,6 @@ class CommonCOMReader(MeshReader):
         if "app_instance" in options.keys():
             del options["app_instance"]
 
+        scene_node = self.nodePostProcessing(scene_node)
+
         return scene_node

--- a/CommonComReader.py
+++ b/CommonComReader.py
@@ -156,7 +156,7 @@ class CommonCOMReader(MeshReader):
 
         # Trying to convert into all formats 1 by 1 and continue with the successful export
         Logger.log("i", "Trying to convert into: %s", fileFormats)
-        temp_scene_node = None
+        scene_node = None
         for file_format in fileFormats:
             Logger.log("d", "Trying to convert <%s> into '%s'", file_path, file_format)
 
@@ -194,14 +194,13 @@ class CommonCOMReader(MeshReader):
                     Logger.log("d", "Found no reader for %s. That's strange...", file_format)
                     continue
                 Logger.log("d", "Using reader: %s", reader.getPluginId())
-                temp_scene_node = reader.read(options["tempFile"])
+                scene_node = reader.read(options["tempFile"])
             except:
                 Logger.logException("e", "Failed to open exported <%s> file in Cura!", file_format)
                 continue
 
             # Remove the temp_file again
             Logger.log("d", "Removing temporary %s file, called <%s>", file_format, options["tempFile"])
-            os.remove(options["tempFile"])
 
             break
 
@@ -217,22 +216,4 @@ class CommonCOMReader(MeshReader):
         if "app_instance" in options.keys():
             del options["app_instance"]
 
-        scene_node = SceneNode()
-        if temp_scene_node is None:
-            return None
-
-        temp_scene_node = self.nodePostProcessing(temp_scene_node)
-        mesh = temp_scene_node.getMeshDataTransformed()
-
-        # When using 3MF as the format to convert into we get an list of meshes instead of only one mesh directly.
-        # This is a little workaround since reloading of 3MF files doesn't work at the moment.
-        if type(mesh) == list:
-            error_message = Message(i18n_catalog.i18nc("@info:status", "Please keep in mind, that you have to reopen your SolidWorks file manually! Reloading the model won't work!"))
-            error_message.show()
-            mesh = mesh.set(file_name = None)
-        else:
-            mesh = mesh.set(file_name = file_path)
-        scene_node.setMeshData(mesh)
-
-        if scene_node:
-            return scene_node
+        return scene_node


### PR DESCRIPTION
CURA-3823

Manually manipulating a SceneNode results in some weird behaviour. The converted file is read by STL or 3MF reader which already returns a valid SceneNode if it succeeds. So, just return that SceneNode instead of manually creating one after.

This is a screenshot after I loaded a PART file:
![image](https://user-images.githubusercontent.com/2630468/29360763-b579e154-8284-11e7-9bdc-facdcfcd96c8.png)
