### PR TITLE
[Fix] Handle the case where the returned node can be a list

### DIFF
--- a/CommonComReader.py
+++ b/CommonComReader.py
@@ -216,6 +216,12 @@ class CommonCOMReader(MeshReader):
         if "app_instance" in options.keys():
             del options["app_instance"]
 
-        scene_node = self.nodePostProcessing(scene_node)
+        # the returned node from STL or 3MF reader can be a node or a list of nodes
+        scene_node_list = scene_node
+        if not isinstance(scene_node, list):
+            scene_node_list = [scene_node]
+
+        for node in scene_node_list:
+            self.nodePostProcessing(node)
 
         return scene_node


### PR DESCRIPTION
CURA-3823

This can happen when SolidWorks 2017 is used. However, with 2016, I get a single node instead of a list.