### PR TITLE
CommonComReader: Commonizing COM modules

### DIFF
--- a/CommonComReader.py
+++ b/CommonComReader.py
@@ -44,10 +44,10 @@ except ImportError:
         def CreateClassObject(app_name):
             return comtypes.client.GetClassObject(app_name).CreateInstance()
 
-        def Coinit():
+        def CoInit():
             comtypes.CoInitializeEx(comtypes.COINIT_MULTITHREADED)
 
-        def UnCoinit():
+        def UnCoInit():
             comtypes.CoUninitialize()
 
     Logger.log("i", "ComFactory: Using comtypes!")

--- a/CommonComReader.py
+++ b/CommonComReader.py
@@ -26,13 +26,7 @@ try:
 
     class ComFactory:
         def CreateClassObject(app_name):
-            win32com.client.gencache.Rebuild()
-            #win32com.client.gencache.EnsureModule(app_name)
-            return win32com.client.gencache.EnsureDispatch(app_name)
-            res = win32com.client.Dispatch("{F16137AD-8EE8-4D2A-8CAC-DFF5D1F67522}")
-            Logger.log("d", "DIR> %s", dir(res()))
-            return res
-            #return win32com.client.Dispatch(app_name)
+            return win32com.client.Dispatch(app_name)
 
         def Coinit():
             pythoncom.CoInitializeEx(pythoncom.COINIT_MULTITHREADED)

--- a/CommonComReader.py
+++ b/CommonComReader.py
@@ -18,7 +18,6 @@ from UM.Scene.SceneNode import SceneNode
 
 # Trying to import one of the COM modules
 try:
-
     import win32com.client
     import win32com.client.gencache
     import pythoncom

--- a/CommonComReader.py
+++ b/CommonComReader.py
@@ -167,7 +167,7 @@ class CommonCOMReader(MeshReader):
         # Starting app and Coinit before
         ComFactory.Coinit()
         try:
-            options = self.startApp(options)
+            self.startApp(options)
         except Exception:
             Logger.logException("e", "Failed to start <%s>...", self._app_name)
             error_message = Message(i18n_catalog.i18nc("@info:status", "Error while starting {}!".format(self._app_friendly_name)))

--- a/SolidWorksReader.py
+++ b/SolidWorksReader.py
@@ -46,7 +46,7 @@ class SolidWorksReader(CommonCOMReader):
                                    "fine": SolidWorksEnums.swSTLQuality_e.swSTLQuality_Fine}
 
         self.root_component = None
-        
+
     @property
     def _file_formats_first_choice(self):
         _file_formats_first_choice = [] # Ordered list of preferred formats
@@ -88,17 +88,17 @@ class SolidWorksReader(CommonCOMReader):
 
     def startApp(self, options):
         options = super().startApp(options)
-        
+
         # Allow SolidWorks to run in the background and be invisible
         options["app_instance"].UserControl = False
-        
+
         #  ' If the following property is true, then the SolidWorks frame will be visible on a call to ISldWorks::ActivateDoc2; so set it to false
         options["app_instance"].Visible = False
 
         # Keep SolidWorks frame invisible when ISldWorks::ActivateDoc2 is called
         options["app_frame"] = options["app_instance"].Frame()
         options["app_frame"].KeepInvisible = True
-        
+
         # Getting revision after starting
         revision_number = options["app_instance"].RevisionNumber()
         Logger.log("d", "SolidWorks RevisionNumber: %s", revision_number)
@@ -128,7 +128,7 @@ class SolidWorksReader(CommonCOMReader):
             # Same here. By logic I would assume that we need to undo it, but when processing multiple parts, SolidWorks gets confused again..
             # Or there is another sense..
             #options["app_instance"].Visible = True
-            
+
             # TODO: Check whether this can be useful. I assume it will close all documents from all windows.
             #options["app_instance"].CloseAllDocuments(True) # Ensures that all docs have been closed!
             pass


### PR DESCRIPTION
Now we can use PyWin32Com in case it is installed.
Downside: We can't choose between different SolidWorks versions. That's why I have to uninstall other versions I had installed for testing.